### PR TITLE
fix: SQLite tests now use in-memory database instead of live database

### DIFF
--- a/app/server/core/file_processor.py
+++ b/app/server/core/file_processor.py
@@ -11,6 +11,9 @@ from .sql_security import (
 )
 from .constants import NESTED_DELIMITER, LIST_INDEX_DELIMITER
 
+# Database path - can be overridden for testing
+DATABASE_PATH = "db/database.db"
+
 def sanitize_table_name(table_name: str) -> str:
     """
     Sanitize table name for SQLite by removing/replacing bad characters
@@ -55,7 +58,7 @@ def convert_csv_to_sqlite(csv_content: bytes, table_name: str) -> Dict[str, Any]
         df.columns = [col.lower().replace(' ', '_').replace('-', '_') for col in df.columns]
         
         # Connect to SQLite database
-        conn = sqlite3.connect("db/database.db")
+        conn = sqlite3.connect(DATABASE_PATH)
         
         # Write DataFrame to SQLite
         df.to_sql(table_name, conn, if_exists='replace', index=False)
@@ -127,7 +130,7 @@ def convert_json_to_sqlite(json_content: bytes, table_name: str) -> Dict[str, An
         df.columns = [col.lower().replace(' ', '_').replace('-', '_') for col in df.columns]
         
         # Connect to SQLite database
-        conn = sqlite3.connect("db/database.db")
+        conn = sqlite3.connect(DATABASE_PATH)
         
         # Write DataFrame to SQLite
         df.to_sql(table_name, conn, if_exists='replace', index=False)
@@ -287,7 +290,7 @@ def convert_jsonl_to_sqlite(jsonl_content: bytes, table_name: str) -> Dict[str, 
         df.columns = [col.lower().replace(' ', '_').replace('-', '_') for col in df.columns]
         
         # Connect to SQLite database
-        conn = sqlite3.connect("db/database.db")
+        conn = sqlite3.connect(DATABASE_PATH)
         
         # Write DataFrame to SQLite
         df.to_sql(table_name, conn, if_exists='replace', index=False)

--- a/app/server/tests/core/test_file_processor.py
+++ b/app/server/tests/core/test_file_processor.py
@@ -1,22 +1,16 @@
 import pytest
-import sqlite3
 from pathlib import Path
 from unittest.mock import patch
+from core import file_processor
 from core.file_processor import convert_csv_to_sqlite, convert_json_to_sqlite, convert_jsonl_to_sqlite, flatten_json_object, discover_jsonl_fields
 
 
 @pytest.fixture
 def test_db():
     """Create an in-memory test database"""
-    # Create in-memory database
-    conn = sqlite3.connect(':memory:')
-    
-    # Patch the database connection to use our in-memory database
-    with patch('core.file_processor.sqlite3.connect') as mock_connect:
-        mock_connect.return_value = conn
-        yield conn
-    
-    conn.close()
+    # Patch the database path to use in-memory database
+    with patch.object(file_processor, 'DATABASE_PATH', ':memory:'):
+        yield None
 
 
 @pytest.fixture


### PR DESCRIPTION
- Added DATABASE_PATH module variable to file_processor.py
- Updated all conversion functions to use configurable database path
- Fixed test fixture to properly patch DATABASE_PATH
- Removed unused sqlite3 import from tests
- Tests are now fully isolated from production database

Fixes issue-111

🤖 Generated with [Claude Code](https://claude.com/claude-code)